### PR TITLE
Change plugin id to match name in package.json

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="com.streethawk.core" version="1.10.0" xmlns="http://apache.org/cordova/ns/plugins/1.0"
+<plugin id="streethawkanalytics" version="1.10.0" xmlns="http://apache.org/cordova/ns/plugins/1.0"
 	xmlns:android="http://schemas.android.com/apk/res/android">
 	<name>StreetHawkCore</name>
 	<description>StreetHawk SDK plugin for analytics</description>


### PR DESCRIPTION
Such that after I've added (`cordova plugin add streethawkanalytics`) and saved the package into my cordova project's config.xml, I can run `cordova prepare` on a fresh clone of the project base code, and all my dependencies will get downloaded and installed successfully. 

```
cordova plugin add streethawkanalytics --variable APP_KEY=XXXXXXXX --variable URL_SCHEME=xxxxxxxx
...
Adding com.streethawk.core to package.json
Saved plugin info for "com.streethawk.core" to config.xml
```

```
Discovered plugin "com.streethawk.core" in config.xml. Adding it to the project
Failed to restore plugin "com.streethawk.core" from config.xml. You might need to try adding it again. Error: Failed to fetch plugin com.streethawk.core@~1.10.0 via registry.
Probably this is either a connection problem, or plugin spec is incorrect.
Check your connection and plugin name/version/URL.
Error: npm: Command failed with exit code 1 Error output:
npm ERR! code E404
npm ERR! 404 Not Found: com.streethawk.core@~1.10.0
```

***

Workaround for now is to rename `com.streethawk.core` to `streethawkanalytics` in config.xml.

```
- <plugin name="com.streethawk.core" spec="~1.10.1">
+ <plugin name="streethawkanalytics" spec="~1.10.1">
```